### PR TITLE
Add support for custom query arguments

### DIFF
--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -85,6 +85,7 @@ export default function PostTemplateEdit( {
 			inherit,
 			taxQuery,
 			parents,
+			customQueryArgs,
 		} = {},
 		queryContext = [ { page: 1 } ],
 		templateSlug,
@@ -157,7 +158,10 @@ export default function PostTemplateEdit( {
 				}
 			}
 			return {
-				posts: getEntityRecords( 'postType', postType, query ),
+				posts: getEntityRecords( 'postType', postType, {
+					...query,
+					...customQueryArgs,
+				} ),
 				blocks: getBlocks( clientId ),
 			};
 		},
@@ -177,6 +181,7 @@ export default function PostTemplateEdit( {
 			templateSlug,
 			taxQuery,
 			parents,
+			customQueryArgs,
 		]
 	);
 	const blockContexts = useMemo(


### PR DESCRIPTION
⚠️ This PR is only a proof of concept to validate the idea. Before creating a PR to the Gutenberg repo, it is necessary to create a better description.

This PR adds support for custom query arguments for the Query Loop block. In this way, the variations can fetch requests to the WordPress REST API with custom query arguments.

You can find an example https://github.com/woocommerce/woocommerce-blocks/pull/6975